### PR TITLE
Update API base URL in frontend .env file

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,1 @@
-VITE_API_BASE_URL=http://localhost:5000
-
-# VITE_API_BASE_URL=https://snm-medical-backend.vercel.app
+VITE_API_BASE_URL=https://snm-medical.onrender.com/


### PR DESCRIPTION
Changed VITE_API_BASE_URL to point to the production endpoint on Render instead of localhost or the commented Vercel URL.